### PR TITLE
Phase 2 Quick Wins: Doc clarifications and logging fixes (10N-247, 10N-248, 10N-249)

### DIFF
--- a/.security-ignore
+++ b/.security-ignore
@@ -92,9 +92,6 @@ scripts/dev-server.ts|cors-wildcard|Development server only, not production
 docs/**/*.md|hardcoded-secrets|Documentation examples with dummy credentials
 README.md|hardcoded-secrets|Documentation examples
 
-# Prompt templates are for AI agents, not production code
-
-
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # SPECIFIC FLRTS PATTERNS
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/docs/FUTURE_FEATURES.md
+++ b/docs/FUTURE_FEATURES.md
@@ -1,18 +1,27 @@
 # Future Features
 
-This document tracks features and enhancements that are planned for future development but not currently prioritized for the MVP or immediate sprints. This is the canonical location for recording post-MVP feature ideas and technical debt items.
+This document tracks features and enhancements that are planned for future
+development but not currently prioritized for the MVP or immediate sprints. This
+is the canonical location for recording post-MVP feature ideas and technical
+debt items.
 
-**Note**: This document has been updated (2025-10-01) to reflect the ERPNext backend adoption ([10N-227](https://linear.app/10netzero/issue/10N-227)). All features are now mapped to ERPNext DocTypes and implementation patterns.
+**Note**: This document has been updated (2025-10-01) to reflect the ERPNext
+backend adoption ([10N-227](https://linear.app/10netzero/issue/10N-227)). All
+features are now mapped to ERPNext DocTypes and implementation patterns.
 
 ## ERPNext Schema Enhancements (Post-MVP)
 
 ### Parser Metadata Tracking
-**Priority:** High (Post-MVP Phase 1)
-**Description:** Add comprehensive metadata tracking for NLP parser performance, model versions, and confidence scores to monitor and improve task creation accuracy over time.
 
-**Current State:** MVP creates tasks via Telegram without tracking parser metadata
+**Priority:** High (Post-MVP Phase 1) **Description:** Add comprehensive
+metadata tracking for NLP parser performance, model versions, and confidence
+scores to monitor and improve task creation accuracy over time.
+
+**Current State:** MVP creates tasks via Telegram without tracking parser
+metadata
 
 **Requirements:**
+
 - Add to `tasks` table (or ERPNext Maintenance Visit custom fields):
   - `parser_confidence` DECIMAL(3,2) - Confidence score from GPT-4o (0.00-1.00)
   - `parser_version` VARCHAR(50) - Parser version/commit hash
@@ -26,24 +35,30 @@ This document tracks features and enhancements that are planned for future devel
 - Alert system for degraded parser performance
 
 **ERPNext Implementation:**
-- Custom fields on Maintenance Visit: `custom_parser_confidence`, `custom_parser_model`, `custom_parser_version`
+
+- Custom fields on Maintenance Visit: `custom_parser_confidence`,
+  `custom_parser_model`, `custom_parser_version`
 - Custom Report: "NLP Parser Performance Dashboard"
 - Server script to track parsing metrics
 
-**Context:** Helps identify when model changes or prompt engineering updates improve or degrade parsing quality. Critical for maintaining high accuracy as the system scales.
+**Context:** Helps identify when model changes or prompt engineering updates
+improve or degrade parsing quality. Critical for maintaining high accuracy as
+the system scales.
 
-**Estimated Effort:** 1 sprint
-**Dependencies:** ERPNext custom fields, reporting dashboard, parser service updates
+**Estimated Effort:** 1 sprint **Dependencies:** ERPNext custom fields,
+reporting dashboard, parser service updates
 
 ---
 
 ### User Notification Preferences
-**Priority:** High (Post-MVP Phase 1)
-**Description:** Per-user notification preferences for reminder timing, daily summaries, and quiet hours.
+
+**Priority:** High (Post-MVP Phase 1) **Description:** Per-user notification
+preferences for reminder timing, daily summaries, and quiet hours.
 
 **Current State:** MVP has basic reminders without user customization
 
 **Requirements:**
+
 - Add to `personnel` / `flrts_users` table (or ERPNext User custom fields):
   - `reminder_minutes_before` INTEGER DEFAULT 30 - Default reminder lead time
   - `daily_summary_enabled` BOOLEAN DEFAULT FALSE - Enable daily task digest
@@ -59,27 +74,35 @@ This document tracks features and enhancements that are planned for future devel
 - Timezone-aware delivery
 
 **ERPNext Implementation:**
-- Custom fields on User DocType: `custom_reminder_minutes`, `custom_daily_summary_enabled`, `custom_daily_summary_time`
-- Custom DocType: "FLRTS User Notification Preferences" (child table with notification type rules)
+
+- Custom fields on User DocType: `custom_reminder_minutes`,
+  `custom_daily_summary_enabled`, `custom_daily_summary_time`
+- Custom DocType: "FLRTS User Notification Preferences" (child table with
+  notification type rules)
 - Server script to check preferences before sending notifications
 
-**Context:** Users have different work patterns and notification preferences. Giving them control improves satisfaction and reduces notification fatigue.
+**Context:** Users have different work patterns and notification preferences.
+Giving them control improves satisfaction and reduces notification fatigue.
 
-**Estimated Effort:** 1-2 sprints
-**Dependencies:** User settings UI, notification service refactor
+**Estimated Effort:** 1-2 sprints **Dependencies:** User settings UI,
+notification service refactor
 
 ---
 
 ### Notification Engagement Tracking
-**Priority:** Medium (Post-MVP Phase 2)
-**Description:** Track notification delivery, read status, and user actions to measure notification effectiveness and improve delivery.
+
+**Priority:** Medium (Post-MVP Phase 2) **Description:** Track notification
+delivery, read status, and user actions to measure notification effectiveness
+and improve delivery.
 
 **Current State:** MVP sends notifications without tracking engagement
 
 **Requirements:**
+
 - Add to `notifications_log` table (or ERPNext custom Notification Log):
   - `read_at` TIMESTAMPTZ - When user viewed notification
-  - `action_taken` VARCHAR(50) - What user did (clicked, dismissed, snoozed, completed_task)
+  - `action_taken` VARCHAR(50) - What user did (clicked, dismissed, snoozed,
+    completed_task)
   - `action_taken_at` TIMESTAMPTZ - When action occurred
   - `retry_count` INTEGER DEFAULT 0 - Delivery retry attempts
   - `delivery_error` TEXT - Last delivery error message
@@ -93,25 +116,29 @@ This document tracks features and enhancements that are planned for future devel
 - A/B testing framework for notification formats
 
 **ERPNext Implementation:**
+
 - Custom DocType: "FLRTS Notification Log" with engagement fields
 - Custom Report: "Notification Effectiveness Dashboard"
 - Webhook from Telegram bot to record read receipts
 - Server script to track action events
 
-**Context:** Helps optimize notification timing, format, and channels. Identifies which notifications drive action vs. create noise.
+**Context:** Helps optimize notification timing, format, and channels.
+Identifies which notifications drive action vs. create noise.
 
-**Estimated Effort:** 2 sprints
-**Dependencies:** Telegram bot webhook, analytics infrastructure
+**Estimated Effort:** 2 sprints **Dependencies:** Telegram bot webhook,
+analytics infrastructure
 
 ---
 
 ### Document Access Tracking
-**Priority:** Low (Post-MVP Phase 3)
-**Description:** Track when documents and media files are last accessed to identify stale content for cleanup.
+
+**Priority:** Low (Post-MVP Phase 3) **Description:** Track when documents and
+media files are last accessed to identify stale content for cleanup.
 
 **Current State:** MVP has document storage without access tracking
 
 **Requirements:**
+
 - Add to `brain_bot_documents` and `brain_bot_media_files`:
   - `last_accessed_at` TIMESTAMPTZ - Last time document was viewed
   - `access_count` INTEGER DEFAULT 0 - Total access count
@@ -124,24 +151,30 @@ This document tracks features and enhancements that are planned for future devel
 - Cleanup workflow for archiving unused content
 
 **ERPNext Implementation:**
+
 - Custom fields on File DocType: `custom_last_accessed`, `custom_access_count`
 - Server script to auto-update on file access
 - Custom Report: "Stale Documents Cleanup List"
 
-**Context:** Knowledge base grows over time. Tracking access helps identify outdated content for cleanup, improving search relevance and storage costs.
+**Context:** Knowledge base grows over time. Tracking access helps identify
+outdated content for cleanup, improving search relevance and storage costs.
 
-**Estimated Effort:** 1 sprint
-**Dependencies:** File access hooks, cleanup automation
+**Estimated Effort:** 1 sprint **Dependencies:** File access hooks, cleanup
+automation
 
 ---
 
 ### Enhanced Audit Trail
-**Priority:** Medium (Post-MVP Phase 2)
-**Description:** Forensic-level audit logging for task changes, including IP address, user agent, and client type for security and compliance.
 
-**Current State:** MVP has basic `task_assignment_history` without forensic details
+**Priority:** Medium (Post-MVP Phase 2) **Description:** Forensic-level audit
+logging for task changes, including IP address, user agent, and client type for
+security and compliance.
+
+**Current State:** MVP has basic `task_assignment_history` without forensic
+details
 
 **Requirements:**
+
 - Add to `task_assignment_history` (or ERPNext Version Control):
   - `ip_address` INET - User's IP address
   - `user_agent` TEXT - Browser/client user agent string
@@ -155,41 +188,57 @@ This document tracks features and enhancements that are planned for future devel
 - Configurable retention policy (e.g., 7 years for compliance)
 
 **ERPNext Implementation:**
+
 - ERPNext has built-in Version Control - enhance with custom fields
 - Custom Report: "Audit Trail Export (Compliance)"
 - Server script to capture IP/user agent on all changes
 - Integration with security monitoring tools
 
-**Context:** Helps investigate security incidents, meet compliance requirements, and understand user behavior patterns.
+**Context:** Helps investigate security incidents, meet compliance requirements,
+and understand user behavior patterns.
 
-**Estimated Effort:** 1-2 sprints
-**Dependencies:** Enhanced logging infrastructure, GDPR compliance review
+**Estimated Effort:** 1-2 sprints **Dependencies:** Enhanced logging
+infrastructure, GDPR compliance review
 
 ---
 
 ## Security & Authentication
 
 ### Advanced Prompt Injection Protection with User Scoping
-**Priority:** High (Post-MVP Phase 2)
-**Description:** Implement comprehensive prompt injection protection for the Telegram task creation workflow using LLMGuard or similar security framework, combined with a user scoping system that limits the blast radius of malicious content based on user privilege levels and data isolation boundaries.
 
-**Current State:** Basic input validation only (length limits, basic content filtering). All users operate at same privilege level with access to shared data.
+**Priority:** High (Post-MVP Phase 2) **Description:** Implement comprehensive
+prompt injection protection for the Telegram task creation workflow using
+LLMGuard or similar security framework, combined with a user scoping system that
+limits the blast radius of malicious content based on user privilege levels and
+data isolation boundaries.
+
+**Current State:** Basic input validation only (length limits, basic content
+filtering). All users operate at same privilege level with access to shared
+data.
 
 **Requirements:**
 
 **Security Framework:**
+
 - Integrate LLMGuard or equivalent prompt injection detection
 - Implement content filtering for malicious patterns
 - Add monitoring and alerting for detected injection attempts
 - Create fallback workflows for blocked inputs
 
 **User Scoping & Privilege System:**
-- **User Risk Levels**: Define user categories (Guest, Employee, Supervisor, Admin) with different UGC risk tolerances
-- **Data Isolation Boundaries**: Implement scoped access where certain user levels can only affect their own data or team-specific elements
-- **Privilege-Based Processing**: Different prompt processing strictness based on user level (e.g., Guests get maximum filtering, Admins get minimal filtering)
-- **Blast Radius Limitation**: Ensure malicious prompts can only affect the user's own tasks/data, not system-wide or other users' data
+
+- **User Risk Levels**: Define user categories (Guest, Employee, Supervisor,
+  Admin) with different UGC risk tolerances
+- **Data Isolation Boundaries**: Implement scoped access where certain user
+  levels can only affect their own data or team-specific elements
+- **Privilege-Based Processing**: Different prompt processing strictness based
+  on user level (e.g., Guests get maximum filtering, Admins get minimal
+  filtering)
+- **Blast Radius Limitation**: Ensure malicious prompts can only affect the
+  user's own tasks/data, not system-wide or other users' data
 
 **Scoping Schema Design (Future Planning):**
+
 - User-specific task namespaces
 - Team-based data segregation
 - Role-based prompt processing policies
@@ -197,33 +246,43 @@ This document tracks features and enhancements that are planned for future devel
 - Cross-user impact prevention mechanisms
 
 **Security Isolation Examples:**
+
 - Guest users: Can only create/modify their own tasks, heavy prompt filtering
 - Field employees: Can affect team tasks but not other teams, moderate filtering
 - Supervisors: Can affect department-wide tasks, light filtering
 - Admins: System-wide access with audit logging, minimal filtering
 
 **ERPNext Implementation:**
+
 - Use ERPNext's native Role Permission system for data isolation
 - Custom Permission Rules for row-level security
 - Custom validation scripts with LLMGuard integration
 - Server script to enforce privilege-based prompt filtering
 
-**Context:** Identified during Story 1.3 security review. Current MVP approach uses trusted user base and basic validation, but production deployment requires comprehensive protection against prompt injection attacks AND a way to limit the damage scope based on user privilege levels and data ownership boundaries.
+**Context:** Identified during Story 1.3 security review. Current MVP approach
+uses trusted user base and basic validation, but production deployment requires
+comprehensive protection against prompt injection attacks AND a way to limit the
+damage scope based on user privilege levels and data ownership boundaries.
 
-**Estimated Effort:** 3-4 sprints (2 for security framework, 1-2 for scoping system)
-**Dependencies:** LLMGuard integration, monitoring infrastructure, user management system redesign, ERPNext permission configuration
+**Estimated Effort:** 3-4 sprints (2 for security framework, 1-2 for scoping
+system) **Dependencies:** LLMGuard integration, monitoring infrastructure, user
+management system redesign, ERPNext permission configuration
 
 ---
 
 ## Notifications & Integrations
 
 ### Telegram Bot Integration
-**Priority:** Medium (Post-MVP Phase 2)
-**Description:** Implement native Telegram bot integration for task creation, updates, and notifications without requiring the Mini App interface.
 
-**Current State:** Telegram Mini App integration planned for MVP (web-based interface)
+**Priority:** Medium (Post-MVP Phase 2) **Description:** Implement native
+Telegram bot integration for task creation, updates, and notifications without
+requiring the Mini App interface.
+
+**Current State:** Telegram Mini App integration planned for MVP (web-based
+interface)
 
 **Requirements:**
+
 - Native Telegram Bot API integration using polling or webhooks
 - Slash commands for task operations (/create, /list, /update, /complete)
 - Inline keyboards for quick task actions (assign, prioritize, complete)
@@ -237,25 +296,31 @@ This document tracks features and enhancements that are planned for future devel
 - Direct message support for personal task lists
 
 **ERPNext Implementation:**
+
 - ERPNext Webhook DocType triggers Telegram notifications
 - n8n workflow receives ERPNext webhooks → formats → sends Telegram messages
 - Telegram bot commands call ERPNext REST API
 - Use ERPNext's Comment feature for Telegram thread integration
 
-**Context:** While the MVP uses a Telegram Mini App, many users prefer native bot interactions for speed and simplicity. Native bot commands provide faster task creation and management without opening a web interface.
+**Context:** While the MVP uses a Telegram Mini App, many users prefer native
+bot interactions for speed and simplicity. Native bot commands provide faster
+task creation and management without opening a web interface.
 
-**Estimated Effort:** 2-3 sprints
-**Dependencies:** Telegram Bot API, webhook infrastructure, notification queue system, ERPNext API
+**Estimated Effort:** 2-3 sprints **Dependencies:** Telegram Bot API, webhook
+infrastructure, notification queue system, ERPNext API
 
 ---
 
 ### Slack App Integration
-**Priority:** Medium (Post-MVP Phase 3)
-**Description:** Create a comprehensive Slack app for task management within Slack workspaces, enabling natural language task creation and team collaboration.
+
+**Priority:** Medium (Post-MVP Phase 3) **Description:** Create a comprehensive
+Slack app for task management within Slack workspaces, enabling natural language
+task creation and team collaboration.
 
 **Current State:** No Slack integration currently planned
 
 **Requirements:**
+
 - Slack App with OAuth 2.0 authentication
 - Slash commands (/flrts-create, /flrts-list, /flrts-assign)
 - Interactive messages with buttons and select menus
@@ -272,24 +337,30 @@ This document tracks features and enhancements that are planned for future devel
 - Workflow builder integration for automation
 
 **ERPNext Implementation:**
+
 - Similar pattern to Telegram: ERPNext webhooks → n8n → Slack
 - Slack commands → n8n → ERPNext REST API
 - Use ERPNext Project DocType for Slack channel associations
 
-**Context:** Many organizations use Slack as their primary communication platform. Native Slack integration would enable seamless task management without context switching, improving adoption and team collaboration.
+**Context:** Many organizations use Slack as their primary communication
+platform. Native Slack integration would enable seamless task management without
+context switching, improving adoption and team collaboration.
 
-**Estimated Effort:** 3-4 sprints
-**Dependencies:** Slack API, OAuth infrastructure, event subscription handling, Block Kit UI components
+**Estimated Effort:** 3-4 sprints **Dependencies:** Slack API, OAuth
+infrastructure, event subscription handling, Block Kit UI components
 
 ---
 
 ### Multi-Channel Notification System
-**Priority:** High (Post-MVP Phase 2)
-**Description:** Unified notification framework supporting multiple channels with user preferences and intelligent routing.
+
+**Priority:** High (Post-MVP Phase 2) **Description:** Unified notification
+framework supporting multiple channels with user preferences and intelligent
+routing.
 
 **Current State:** Basic email notifications planned for MVP
 
 **Requirements:**
+
 - Centralized notification service with channel abstraction
 - Supported channels:
   - Email (enhanced with templates and tracking)
@@ -313,28 +384,35 @@ This document tracks features and enhancements that are planned for future devel
 - Webhook support for custom integrations
 
 **ERPNext Implementation:**
+
 - Custom DocType: "FLRTS Notification Rule" (routing rules)
 - Custom DocType: "FLRTS Notification Template" (message templates)
 - Server script to process notifications based on user preferences
 - Integration with n8n for multi-channel delivery
 - Use ERPNext's Notification DocType as foundation
 
-**Context:** Different users prefer different notification channels based on their workflow and urgency. A unified system ensures reliable delivery while respecting user preferences and preventing notification overload.
+**Context:** Different users prefer different notification channels based on
+their workflow and urgency. A unified system ensures reliable delivery while
+respecting user preferences and preventing notification overload.
 
-**Estimated Effort:** 4-5 sprints
-**Dependencies:** Message queue system, template engine, third-party APIs (Twilio, SendGrid, etc.), user preference storage
+**Estimated Effort:** 4-5 sprints **Dependencies:** Message queue system,
+template engine, third-party APIs (Twilio, SendGrid, etc.), user preference
+storage
 
 ---
 
 ## Equipment & Asset Management (Post-MVP)
 
 ### Equipment Service History Tracking
-**Priority:** High (Post-MVP Phase 2)
-**Description:** Link equipment and ASICs to field reports and maintenance visits for complete service history tracking.
 
-**Current State:** MVP has `field_reports_asics` and `field_reports_equipment` junction tables
+**Priority:** High (Post-MVP Phase 2) **Description:** Link equipment and ASICs
+to field reports and maintenance visits for complete service history tracking.
+
+**Current State:** MVP has `field_reports_asics` and `field_reports_equipment`
+junction tables
 
 **Requirements:**
+
 - Complete integration with ERPNext's Serial No and Asset tracking
 - Service history timeline view per equipment/ASIC
 - Maintenance cost tracking per asset
@@ -343,6 +421,7 @@ This document tracks features and enhancements that are planned for future devel
 - Equipment failure analysis and reporting
 
 **ERPNext Implementation:**
+
 - Use standard **Serial No** DocType for ASIC tracking
 - Use standard **Asset** DocType for equipment
 - Link Maintenance Visit (field reports) to Serial No/Asset
@@ -350,22 +429,25 @@ This document tracks features and enhancements that are planned for future devel
 - Custom Report: "ASIC Failure Analysis"
 - Server script for predictive maintenance alerts
 
-**Context:** Mining operations require detailed equipment tracking for cost management, warranty claims, and operational efficiency.
+**Context:** Mining operations require detailed equipment tracking for cost
+management, warranty claims, and operational efficiency.
 
-**Estimated Effort:** 3-4 sprints
-**Dependencies:** ERPNext Asset Management module, Maintenance Visit integration
+**Estimated Effort:** 3-4 sprints **Dependencies:** ERPNext Asset Management
+module, Maintenance Visit integration
 
 ---
 
 ## Financial & Billing (Post-MVP)
 
 ### Partner Billing Automation
-**Priority:** Medium (Post-MVP Phase 3)
-**Description:** Automate billing for mining partners based on hashrate agreements and service contracts.
+
+**Priority:** Medium (Post-MVP Phase 3) **Description:** Automate billing for
+mining partners based on hashrate agreements and service contracts.
 
 **Current State:** `partner_billings` table exists but not integrated
 
 **Requirements:**
+
 - Link `licenses_agreements` (hashrate contracts) to billing cycles
 - Automated invoice generation based on agreement terms
 - Integration with ERPNext's Sales Invoice
@@ -374,26 +456,30 @@ This document tracks features and enhancements that are planned for future devel
 - Multi-currency support for international partners
 
 **ERPNext Implementation:**
+
 - Use standard **Sales Invoice** DocType
 - Link to custom "FLRTS License Agreement" DocType
 - Subscription DocType for recurring billing
 - Custom Report: "Partner Billing Dashboard"
 - Payment Entry integration for reconciliation
 
-**Context:** Automates revenue tracking and ensures accurate billing based on complex hashrate agreements.
+**Context:** Automates revenue tracking and ensures accurate billing based on
+complex hashrate agreements.
 
-**Estimated Effort:** 3-4 sprints
-**Dependencies:** ERPNext Accounting module, license agreement implementation
+**Estimated Effort:** 3-4 sprints **Dependencies:** ERPNext Accounting module,
+license agreement implementation
 
 ---
 
 ### Vendor Invoice Management
-**Priority:** Medium (Post-MVP Phase 3)
-**Description:** Track vendor invoices for equipment, parts, and contractor services.
+
+**Priority:** Medium (Post-MVP Phase 3) **Description:** Track vendor invoices
+for equipment, parts, and contractor services.
 
 **Current State:** `vendor_invoices` table exists but not integrated
 
 **Requirements:**
+
 - Link invoices to maintenance visits and equipment purchases
 - Integration with ERPNext's Purchase Invoice
 - Approval workflows for invoice verification
@@ -401,15 +487,17 @@ This document tracks features and enhancements that are planned for future devel
 - Vendor performance analytics
 
 **ERPNext Implementation:**
+
 - Use standard **Purchase Invoice** DocType
 - Link to Maintenance Visit via custom fields
 - Use ERPNext's Approval workflow
 - Custom Report: "Vendor Cost Analysis by Site"
 
-**Context:** Ensures accurate cost tracking and vendor accountability for mining operations.
+**Context:** Ensures accurate cost tracking and vendor accountability for mining
+operations.
 
-**Estimated Effort:** 2-3 sprints
-**Dependencies:** ERPNext Buying module, Maintenance Visit integration
+**Estimated Effort:** 2-3 sprints **Dependencies:** ERPNext Buying module,
+Maintenance Visit integration
 
 ---
 
@@ -418,12 +506,14 @@ This document tracks features and enhancements that are planned for future devel
 When adding new future features, use this template:
 
 ### [Feature Name]
-**Priority:** [High/Medium/Low] ([Timeline])
-**Description:** [Brief description of the feature]
+
+**Priority:** [High/Medium/Low] ([Timeline]) **Description:** [Brief description
+of the feature]
 
 **Current State:** [What exists now, if anything]
 
 **Requirements:**
+
 - [Key requirement 1]
 - [Key requirement 2]
 - [etc.]
@@ -432,11 +522,10 @@ When adding new future features, use this template:
 
 **Context:** [Why this is needed, background information]
 
-**Estimated Effort:** [Time estimate]
-**Dependencies:** [Technical or business dependencies]
+**Estimated Effort:** [Time estimate] **Dependencies:** [Technical or business
+dependencies]
 
 ---
 
-*Last Updated: 2025-10-01*
-*Managed by: Development Team*
-*ERPNext Migration: Phase 1 Complete (Schema Philosophy, Functional Requirements, DocType Patterns)*
+_Last Updated: 2025-10-01_ _Managed by: Development Team_ _ERPNext Migration:
+Phase 1 Complete (Schema Philosophy, Functional Requirements, DocType Patterns)_

--- a/docs/MVP-FEATURES.md
+++ b/docs/MVP-FEATURES.md
@@ -1,19 +1,27 @@
 # MVP Features (Critical for Launch)
 
-This document tracks features that MUST be implemented for the MVP launch. These are non-negotiable requirements for a functional minimum viable product.
+This document tracks features that MUST be implemented for the MVP launch. These
+are non-negotiable requirements for a functional minimum viable product.
 
 ## OpenAI Parser Audit Log
-**Priority:** CRITICAL (MVP Required)
-**Status:** Not Yet Implemented
 
-**Description:** Comprehensive logging of all OpenAI API calls for NLP parsing, including inputs, outputs, model rationale, and correction attempts. Essential for debugging, prompt engineering, and understanding model behavior.
+**Priority:** CRITICAL (MVP Required) **Status:** Not Yet Implemented
+
+**Description:** Comprehensive logging of all OpenAI API calls for NLP parsing,
+including inputs, outputs, model rationale, and correction attempts. Essential
+for debugging, prompt engineering, and understanding model behavior.
 
 **Why This Is MVP-Critical:**
-1. **Debugging:** When users report parsing errors, you can see exactly what the model saw and why it made its decision
-2. **Prompt Engineering:** Rationale field tells you what to fix in your prompts to improve accuracy
-3. **Model Comparison:** Track performance across GPT-4o versions and prompt iterations
+
+1. **Debugging:** When users report parsing errors, you can see exactly what the
+   model saw and why it made its decision
+2. **Prompt Engineering:** Rationale field tells you what to fix in your prompts
+   to improve accuracy
+3. **Model Comparison:** Track performance across GPT-4o versions and prompt
+   iterations
 4. **Cost Tracking:** Monitor token usage and API costs for budget planning
-5. **Compliance:** Audit trail of all AI-generated content for regulatory requirements
+5. **Compliance:** Audit trail of all AI-generated content for regulatory
+   requirements
 
 ---
 
@@ -109,10 +117,10 @@ Your OpenAI prompt **MUST** include a `rationale` field in the response schema:
 
 ```typescript
 const openAIRequest = {
-  model: "gpt-4o-2024-08-06",
+  model: 'gpt-4o-2024-08-06',
   messages: [
     {
-      role: "system",
+      role: 'system',
       content: `You are a task parser for FLRTS (Field Reports, Lists, Reminders, Tasks, and Sub-Tasks).
 
 Parse natural language messages into structured task data.
@@ -126,60 +134,68 @@ IMPORTANT: You MUST explain your reasoning in the 'rationale' field. Describe:
 Known Sites: Big Sky, Viper, Crystal Peak, Thunder Ridge
 Known Personnel: Colin, Mike, Sarah, Alex
 Default Times: morning=8am, afternoon=2pm, evening=6pm
-Default Priority: normal (unless urgent/critical/ASAP mentioned)`
+Default Priority: normal (unless urgent/critical/ASAP mentioned)`,
     },
     {
-      role: "user",
-      content: userMessage
-    }
+      role: 'user',
+      content: userMessage,
+    },
   ],
   response_format: {
-    type: "json_schema",
+    type: 'json_schema',
     json_schema: {
-      name: "task_parse_result",
+      name: 'task_parse_result',
       strict: true,
       schema: {
-        type: "object",
+        type: 'object',
         properties: {
           task_title: {
-            type: "string",
-            description: "Concise task title"
+            type: 'string',
+            description: 'Concise task title',
           },
           assignee: {
-            type: "string",
-            description: "Person assigned (must match known personnel or 'unassigned')"
+            type: 'string',
+            description:
+              "Person assigned (must match known personnel or 'unassigned')",
           },
           due_date: {
-            type: "string",
-            description: "ISO date YYYY-MM-DD or null"
+            type: 'string',
+            description: 'ISO date YYYY-MM-DD or null',
           },
           due_time: {
-            type: "string",
-            description: "24hr time HH:MM or null"
+            type: 'string',
+            description: '24hr time HH:MM or null',
           },
           site: {
-            type: "string",
-            description: "Site name (must match known sites) or null"
+            type: 'string',
+            description: 'Site name (must match known sites) or null',
           },
           priority: {
-            type: "string",
-            enum: ["low", "normal", "high", "urgent"],
-            description: "Task priority level"
+            type: 'string',
+            enum: ['low', 'normal', 'high', 'urgent'],
+            description: 'Task priority level',
           },
           confidence: {
-            type: "number",
-            description: "Confidence score 0.0-1.0 for this parse"
+            type: 'number',
+            description: 'Confidence score 0.0-1.0 for this parse',
           },
           rationale: {
-            type: "string",
-            description: "REQUIRED: Explain WHY you structured the output this way. What clues in the message led to each decision? What assumptions did you make? Be specific about how you interpreted dates, times, sites, and assignments."
-          }
+            type: 'string',
+            description:
+              'REQUIRED: Explain WHY you structured the output this way. What clues in the message led to each decision? What assumptions did you make? Be specific about how you interpreted dates, times, sites, and assignments.',
+          },
         },
-        required: ["task_title", "assignee", "priority", "confidence", "rationale"],
-        additionalProperties: false
-      }
-    }
-  }
+        required: [
+          'task_title',
+          'assignee',
+          'priority',
+          'confidence',
+          'rationale',
+        ],
+        additionalProperties: false,
+      },
+    },
+  },
 };
 ```
 
@@ -190,9 +206,11 @@ Default Priority: normal (unless urgent/critical/ASAP mentioned)`
 #### Original Parse Attempt
 
 **User Message:**
+
 > "Colin needs to check the compressor at Big Sky tomorrow afternoon"
 
 **OpenAI Request Logged:**
+
 ```json
 {
   "telegram_message_id": 12345,
@@ -207,6 +225,7 @@ Default Priority: normal (unless urgent/critical/ASAP mentioned)`
 ```
 
 **OpenAI Response:**
+
 ```json
 {
   "task_title": "Check compressor at Big Sky",
@@ -221,18 +240,21 @@ Default Priority: normal (unless urgent/critical/ASAP mentioned)`
 ```
 
 **Logged Fields:**
+
 ```json
 {
-  "parsed_output": { /* JSON above */ },
+  "parsed_output": {
+    /* JSON above */
+  },
   "model_rationale": "Detected 'Colin needs to' as direct assignment...",
   "confidence_score": 0.85,
   "prompt_tokens": 245,
   "completion_tokens": 89,
   "total_tokens": 334,
-  "estimated_cost_usd": 0.001670,
+  "estimated_cost_usd": 0.00167,
   "finish_reason": "stop",
   "response_duration_ms": 1243,
-  "user_accepted": null  // Waiting for user confirmation
+  "user_accepted": null // Waiting for user confirmation
 }
 ```
 
@@ -241,9 +263,11 @@ Default Priority: normal (unless urgent/critical/ASAP mentioned)`
 #### User Rejects and Provides Correction
 
 **User Response:**
+
 > "No, I meant tomorrow MORNING, and it's URGENT"
 
 **System Updates Original Log:**
+
 ```sql
 UPDATE openai_parser_logs
 SET
@@ -256,6 +280,7 @@ WHERE id = '<original_log_id>';
 **New Correction Request to OpenAI:**
 
 System constructs correction prompt:
+
 ```json
 {
   "role": "user",
@@ -264,6 +289,7 @@ System constructs correction prompt:
 ```
 
 **Corrected OpenAI Response:**
+
 ```json
 {
   "task_title": "Check compressor at Big Sky",
@@ -278,6 +304,7 @@ System constructs correction prompt:
 ```
 
 **Logged as Correction:**
+
 ```json
 {
   "is_correction": true,
@@ -285,16 +312,20 @@ System constructs correction prompt:
   "correction_user_feedback": "No, I meant tomorrow MORNING, and it's URGENT",
   "correction_rationale": "User explicitly corrected 'afternoon' to 'morning'...",
   "correction_attempt_number": 2,
-  "parsed_output": { /* Corrected JSON */ },
+  "parsed_output": {
+    /* Corrected JSON */
+  },
   "confidence_score": 0.95,
-  "user_accepted": null  // Waiting for confirmation
+  "user_accepted": null // Waiting for confirmation
 }
 ```
 
 **User Accepts:**
+
 > "Perfect!"
 
 **Final Update:**
+
 ```sql
 UPDATE openai_parser_logs
 SET
@@ -310,6 +341,7 @@ WHERE id = '<correction_log_id>';
 ### Analytics Queries
 
 #### 1. Parser Success Rate Dashboard
+
 ```sql
 SELECT
   DATE(created_at) as date,
@@ -328,6 +360,7 @@ ORDER BY date DESC;
 ```
 
 #### 2. Common Failure Patterns
+
 ```sql
 -- Find the most common user corrections
 SELECT
@@ -344,6 +377,7 @@ LIMIT 20;
 ```
 
 #### 3. Model Rationale Analysis for Failed Parses
+
 ```sql
 -- Export all rationales for rejected parses to identify patterns
 SELECT
@@ -362,6 +396,7 @@ ORDER BY created_at DESC;
 ```
 
 #### 4. Prompt Version A/B Testing
+
 ```sql
 -- Compare performance across different prompt versions
 SELECT
@@ -382,6 +417,7 @@ ORDER BY acceptance_rate DESC, avg_confidence DESC;
 ```
 
 #### 5. Cost Tracking and Budget Alerts
+
 ```sql
 -- Monthly cost projection
 SELECT
@@ -396,6 +432,7 @@ GROUP BY DATE_TRUNC('month', created_at);
 ```
 
 #### 6. Correction Chain Analysis
+
 ```sql
 -- Find messages that required multiple correction attempts
 WITH RECURSIVE correction_chain AS (
@@ -438,9 +475,11 @@ ORDER BY total_attempts DESC;
 
 ### ERPNext Implementation Strategy
 
-Once ERPNext migration is complete, create a Custom DocType: **"FLRTS Parser Audit Log"**
+Once ERPNext migration is complete, create a Custom DocType: **"FLRTS Parser
+Audit Log"**
 
 **Fields:**
+
 - Link to User (telegram_user_id mapped to ERPNext User)
 - Link to Maintenance Visit (created_task_id → Maintenance Visit name)
 - Text fields for: original_message, system_prompt, user_message
@@ -452,12 +491,14 @@ Once ERPNext migration is complete, create a Custom DocType: **"FLRTS Parser Aud
 - Link to self for: original_log_id (correction chain)
 
 **Custom Reports:**
+
 1. "Parser Performance Dashboard" - Success rates, costs, latencies
 2. "Failed Parse Analysis" - Rejection reasons and patterns
 3. "Model Comparison Report" - A/B test different prompts/models
 4. "Cost Tracking Report" - Daily/monthly OpenAI spend
 
 **Server Scripts:**
+
 - Auto-calculate `estimated_cost_usd` based on model pricing
 - Alert if acceptance rate drops below 80%
 - Alert if daily cost exceeds budget threshold
@@ -476,7 +517,8 @@ MVP Launch Requirements:
 - [ ] **Telegram Bot:** Handle correction flow (link to original attempt)
 - [ ] **Telegram Bot:** Update log when task is created (set created_task_id)
 - [ ] **Cost Calculation:** Add pricing lookup for model (gpt-4o pricing)
-- [ ] **Analytics Dashboard:** Create Grafana/Supabase dashboard for success rate
+- [ ] **Analytics Dashboard:** Create Grafana/Supabase dashboard for success
+      rate
 - [ ] **Alerts:** Set up alert for parser success rate drop below 80%
 - [ ] **Alerts:** Set up alert for daily cost exceeding $10 USD
 - [ ] **Documentation:** Document prompt versioning strategy (git commit hash)
@@ -493,6 +535,7 @@ Post-MVP Enhancements:
 ### Estimated Effort
 
 **MVP Implementation:** 3-5 days
+
 - Database schema creation: 4 hours
 - Parser service logging integration: 1 day
 - Telegram bot updates (capture user responses): 1 day
@@ -500,12 +543,12 @@ Post-MVP Enhancements:
 - Testing and validation: 1 day
 
 **ERPNext Migration:** 2-3 days (Post-MVP Phase 2)
+
 - Custom DocType creation
 - Reports and dashboards
 - Server scripts for alerts
 
 ---
 
-*Last Updated: 2025-10-01*
-*Status: MVP Critical - Not Yet Implemented*
-*Owner: Development Team*
+_Last Updated: 2025-10-01_ _Status: MVP Critical - Not Yet Implemented_ _Owner:
+Development Team_

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,5 +1,12 @@
 # FLRTS Technical Architecture Documentation
 
+> ⚠️ **MIGRATION STATUS**: This documentation describes legacy OpenProject
+> architecture. Migration to ERPNext is in progress: **Phase 1 complete**
+> (config layer, stub client), **Phase 2 pending** (live API integration).
+> OpenProject remains the default backend. See
+> [ADR-006](./adr/ADR-006-erpnext-frappe-cloud-migration.md) for migration
+> roadmap.
+
 ## Document Structure
 
 This architecture documentation provides comprehensive technical guidance for

--- a/docs/architecture/frappe-cloud-environment.md
+++ b/docs/architecture/frappe-cloud-environment.md
@@ -1,5 +1,12 @@
 # Frappe Cloud Environment Architecture
 
+> **⚠️ MIGRATION STATUS**: This document describes the **target infrastructure**
+> for ERPNext on Frappe Cloud. **Application migration: Phase 1 complete**
+> (config layer, stub client), **Phase 2 pending** (live API integration).
+> Infrastructure is provisioned but **OpenProject remains the default backend**.
+> See [ADR-006](./adr/ADR-006-erpnext-frappe-cloud-migration.md) for migration
+> roadmap.
+
 **Status**: Active **Supersedes**: OpenProject/Supabase/Cloudflare Tunnel
 architecture (see `docs/archive/`) **Related**:
 [ADR-006 ERPNext Frappe Cloud Migration](./adr/ADR-006-erpnext-frappe-cloud-migration.md)

--- a/docs/deployment/FRAPPE_CLOUD_DEPLOYMENT.md
+++ b/docs/deployment/FRAPPE_CLOUD_DEPLOYMENT.md
@@ -1,5 +1,13 @@
 # Frappe Cloud Deployment Guide
 
+> **⚠️ MIGRATION STATUS**: This deployment guide describes the **target
+> infrastructure** for ERPNext on Frappe Cloud. **Application migration: Phase 1
+> complete** (config layer, stub client), **Phase 2 pending** (live API
+> integration). Infrastructure is provisioned but **OpenProject remains the
+> default backend**. See
+> [ADR-006](../architecture/adr/ADR-006-erpnext-frappe-cloud-migration.md) for
+> migration roadmap.
+
 **Status**: Active **Related**:
 [ADR-006 ERPNext Frappe Cloud Migration](../architecture/adr/ADR-006-erpnext-frappe-cloud-migration.md)
 | [Frappe Cloud Site Setup](../setup/frappe-cloud-site.md) |

--- a/docs/erpnext/research/erpnext-fsm-module-analysis.md
+++ b/docs/erpnext/research/erpnext-fsm-module-analysis.md
@@ -1,14 +1,16 @@
 # ERPNext DocType Patterns & FSM Module Analysis
 
-**Status:** ✅ Complete (Phase 1.3)
-**Phase:** Phase 1.3
-**Related Linear:** [10N-227](https://linear.app/10netzero/issue/10N-227)
-**Source:** Deep Research Report (ERPNext Architectural Patterns)
-**Date Created:** 2025-10-01
+**Status:** ✅ Complete (Phase 1.3) **Phase:** Phase 1.3 **Related Linear:**
+[10N-227](https://linear.app/10netzero/issue/10N-227) **Source:** Deep Research
+Report (ERPNext Architectural Patterns) **Date Created:** 2025-10-01
 
 ## Executive Summary
 
-This document synthesizes the Phase 1.3 deep research on ERPNext DocType design patterns and the Field Service Management (FSM) module ecosystem. **Critical Finding:** ERPNext FSM is NOT a monolithic module but a **constellation of DocTypes** across Support, Selling, and Stock modules that must be orchestrated together.
+This document synthesizes the Phase 1.3 deep research on ERPNext DocType design
+patterns and the Field Service Management (FSM) module ecosystem. **Critical
+Finding:** ERPNext FSM is NOT a monolithic module but a **constellation of
+DocTypes** across Support, Selling, and Stock modules that must be orchestrated
+together.
 
 ---
 
@@ -16,27 +18,33 @@ This document synthesizes the Phase 1.3 deep research on ERPNext DocType design 
 
 ### 1.1 Five Core DocType Patterns
 
-ERPNext's architecture is built on five fundamental patterns. Understanding when to use each is critical for correct data modeling.
+ERPNext's architecture is built on five fundamental patterns. Understanding when
+to use each is critical for correct data modeling.
 
 #### Pattern 1: Master Data DocTypes (The "Nouns")
 
-**Definition:** Core, relatively static business entities that are *referenced* by other documents.
+**Definition:** Core, relatively static business entities that are _referenced_
+by other documents.
 
 **Characteristics:**
+
 - Low transaction volume
 - Long-lasting data
 - Referenced by many transactional documents
 - Foundation of the business system
 
 **When to Use:**
+
 - Modeling core business entities (customers, items, assets, employees)
 - Data will be reused across multiple transactions
 - Record needs to exist independently
 
 **ERPNext Examples:**
+
 - Customer, Supplier, Item, Employee, Asset, Warehouse, Company
 
 **FLRTS Application:**
+
 - Sites/Locations (Master)
 - Contractors/Vendors (Master)
 - Personnel (Master)
@@ -48,20 +56,24 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 **Definition:** High-volume, time-bound documents that record business events.
 
 **Characteristics:**
+
 - High transaction volume
 - Always timestamped
 - Always reference one or more Master DocTypes
 - Often submittable (immutable after finalization)
 
 **When to Use:**
+
 - Recording business events (sales, purchases, service visits)
 - Creating audit trail
 - Capturing time-bound activities
 
 **ERPNext Examples:**
+
 - Sales Order, Purchase Invoice, Stock Entry, Journal Entry, Maintenance Visit
 
 **FLRTS Application:**
+
 - Work Orders (Transactional - records service event)
 - Reminders (Transactional - records notification event)
 
@@ -69,26 +81,31 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 
 #### Pattern 3: Child Table DocTypes (One-to-Many Relationships)
 
-**Definition:** DocTypes that cannot exist independently, embedded within a parent document.
+**Definition:** DocTypes that cannot exist independently, embedded within a
+parent document.
 
 **Characteristics:**
+
 - `istable: 1` property enabled
 - Stores multiple sub-records within parent
 - Automatically managed parent/parenttype/parentfield links
 - Stored in separate database table
 
 **When to Use:**
+
 - Line items (order items, invoice items)
 - Task checklists
 - Parts consumed during service
 - Any one-to-many relationship within a document
 
 **ERPNext Examples:**
+
 - Sales Order Item (child of Sales Order)
 - Purchase Invoice Item (child of Purchase Invoice)
 - Journal Entry Account (child of Journal Entry)
 
 **FLRTS Application:**
+
 - FLRTS List Item (child of FLRTS List)
 - Service Visit Task (child of Maintenance Visit)
 - Service Visit Parts (child of Maintenance Visit)
@@ -101,20 +118,24 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 **Definition:** DocType with only ONE record for entire system.
 
 **Characteristics:**
+
 - `issingle: 1` property enabled
 - No list view (direct form access)
 - Stored in `tabSingles` table (not own table)
 - Used exclusively for global configuration
 
 **When to Use:**
+
 - System-wide settings
 - Global defaults
 - One-per-system configuration
 
 **ERPNext Examples:**
+
 - System Settings, Stock Settings, Selling Settings, Accounts Settings
 
 **FLRTS Application:**
+
 - Not needed (no global configuration DocTypes required)
 
 ---
@@ -122,22 +143,26 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 #### Pattern 5: Specialized Behavioral Patterns
 
 **Submittable DocTypes:**
+
 - `is_submittable: 1` property
 - Workflow: Draft (0) → Submitted (1) → Cancelled (2)
 - Submitted documents are **immutable** (critical for audit trail)
 - Use for financial records, work orders, any document requiring approval
 
 **Tree DocTypes:**
+
 - `is_tree: 1` property
 - Hierarchical self-referential structure
 - Use for nested categories, org charts, geographic territories
 
 **ERPNext Examples:**
+
 - Chart of Accounts (Tree + Submittable)
 - Item Groups (Tree)
 - Territory (Tree)
 
 **FLRTS Application:**
+
 - Location DocType should be Tree (nested site hierarchy)
 - Work Order should be Submittable (immutable after assignment)
 
@@ -147,24 +172,27 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 
 ### 2.1 Critical Finding: FSM is a "Constellation," Not a Module
 
-**ERPNext FSM is NOT a single module with dedicated DocTypes.** It's a **process workflow** that orchestrates standard DocTypes from multiple modules:
+**ERPNext FSM is NOT a single module with dedicated DocTypes.** It's a **process
+workflow** that orchestrates standard DocTypes from multiple modules:
 
-| FLRTS Concept | ERPNext DocType | Module | Primary or Extension |
-|---------------|-----------------|--------|---------------------|
-| Work Request | **Issue** | Support | ✅ Primary (standard) |
-| Scheduled Work Order | **Maintenance Visit** | Support | ✅ Primary (standard) |
-| Recurring Maintenance | **Maintenance Schedule** | Support | ✅ Primary (standard) |
-| Service Commitment | **Service Level Agreement (SLA)** | Support | ✅ Primary (standard) |
-| Site/Location | **Territory** or **Address** | Selling/CRM | ⚠️ Needs extension |
-| Contractor | **Supplier** | Buying | ⚠️ Needs extension |
-| Parts/Materials | **Item** | Stock | ✅ Primary (standard) |
-| Technician | **Sales Person** (linked to Employee) | HR/Selling | ⚠️ Workaround |
+| FLRTS Concept         | ERPNext DocType                       | Module      | Primary or Extension  |
+| --------------------- | ------------------------------------- | ----------- | --------------------- |
+| Work Request          | **Issue**                             | Support     | ✅ Primary (standard) |
+| Scheduled Work Order  | **Maintenance Visit**                 | Support     | ✅ Primary (standard) |
+| Recurring Maintenance | **Maintenance Schedule**              | Support     | ✅ Primary (standard) |
+| Service Commitment    | **Service Level Agreement (SLA)**     | Support     | ✅ Primary (standard) |
+| Site/Location         | **Territory** or **Address**          | Selling/CRM | ⚠️ Needs extension    |
+| Contractor            | **Supplier**                          | Buying      | ⚠️ Needs extension    |
+| Parts/Materials       | **Item**                              | Stock       | ✅ Primary (standard) |
+| Technician            | **Sales Person** (linked to Employee) | HR/Selling  | ⚠️ Workaround         |
 
 ### 2.2 The Standard Work Order DocType is NOT for FSM
 
-**❌ CRITICAL WARNING:** ERPNext's standard **Work Order DocType** is a **manufacturing tool**, NOT a field service tool.
+**❌ CRITICAL WARNING:** ERPNext's standard **Work Order DocType** is a
+**manufacturing tool**, NOT a field service tool.
 
 **Why it's wrong for FSM:**
+
 - Designed for factory production (Item to Manufacture, BOM, WIP Warehouse)
 - Creates finished goods from raw materials
 - Workflow assumes manufacturing operations (material transfer, production)
@@ -180,17 +208,17 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 
 **Standard Fields (Field-by-Field Analysis):**
 
-| Field | Type | Purpose | Required | FLRTS Mapping |
-|-------|------|---------|----------|---------------|
-| `customer` | Link to Customer | Who is being serviced | Yes | FLRTS customer |
-| `maintenance_type` | Select | Scheduled/Unscheduled/Breakdown | Yes | Work order type |
-| `completion_status` | Select | Partially/Fully Completed | Yes | Status tracking |
-| `item_code` | Link to Item | What equipment is being serviced | Yes | Equipment/asset |
-| `serial_no` | Link to Serial No | Specific asset instance | Yes | Asset tracking |
-| `maintenance_schedule` | Link | Links to recurring schedule | No | Recurring work |
-| `sales_person` | Link | Assigned technician (employee) | Yes | Field technician |
-| `work_done` | Small Text | Summary of work performed | Yes | Service notes |
-| `customer_feedback` | Text | Post-visit feedback | No | Customer satisfaction |
+| Field                  | Type              | Purpose                          | Required | FLRTS Mapping         |
+| ---------------------- | ----------------- | -------------------------------- | -------- | --------------------- |
+| `customer`             | Link to Customer  | Who is being serviced            | Yes      | FLRTS customer        |
+| `maintenance_type`     | Select            | Scheduled/Unscheduled/Breakdown  | Yes      | Work order type       |
+| `completion_status`    | Select            | Partially/Fully Completed        | Yes      | Status tracking       |
+| `item_code`            | Link to Item      | What equipment is being serviced | Yes      | Equipment/asset       |
+| `serial_no`            | Link to Serial No | Specific asset instance          | Yes      | Asset tracking        |
+| `maintenance_schedule` | Link              | Links to recurring schedule      | No       | Recurring work        |
+| `sales_person`         | Link              | Assigned technician (employee)   | Yes      | Field technician      |
+| `work_done`            | Small Text        | Summary of work performed        | Yes      | Service notes         |
+| `customer_feedback`    | Text              | Post-visit feedback              | No       | Customer satisfaction |
 
 **🚨 CRITICAL GAPS in Standard Maintenance Visit:**
 
@@ -200,6 +228,7 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 4. **No site/location field** - Only customer address
 
 **Required Customizations:**
+
 - Add child table: `Service Visit Task` (task checklist)
 - Add child table: `Service Visit Part` (parts consumed)
 - Add Link field: `contractor` (Link to Supplier for external techs)
@@ -209,9 +238,11 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 
 ### 2.4 Site/Location Modeling
 
-**ERPNext does NOT have a dedicated "Site" DocType.** Community consensus: Use **Territory + Address** combination.
+**ERPNext does NOT have a dedicated "Site" DocType.** Community consensus: Use
+**Territory + Address** combination.
 
 **✅ RECOMMENDED: Create Custom `Site Location` DocType**
+
 - Combines best of both
 - Link to Customer (who owns site)
 - Link to Address (physical location)
@@ -223,7 +254,10 @@ ERPNext's architecture is built on five fundamental patterns. Understanding when
 
 ## Section 3: Key Findings Summary
 
-See full document at [docs/research/erpnext-fsm-module-analysis.md](docs/research/erpnext-fsm-module-analysis.md) for:
+See full document at
+[docs/research/erpnext-fsm-module-analysis.md](docs/research/erpnext-fsm-module-analysis.md)
+for:
+
 - Complete DocType JSON templates
 - Custom app structure (`flrts_extensions`)
 - Integration patterns (REST API, Webhooks)
@@ -232,4 +266,5 @@ See full document at [docs/research/erpnext-fsm-module-analysis.md](docs/researc
 
 ---
 
-**Phase 1.3 Complete:** All deep research findings documented and integrated into Phase 1.2 deliverables.
+**Phase 1.3 Complete:** All deep research findings documented and integrated
+into Phase 1.2 deliverables.

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -41,10 +41,14 @@ Conversational task creation with automatic timezone handling **Target Users**:
 Distributed bitcoin mining operations team **Timeline**: 12-week MVP across 4
 epics **Tech Stack**: TypeScript, OpenAI GPT-4o, ERPNext REST API, Frappe Cloud
 
-## Key Decision: ERPNext on Frappe Cloud
+## Key Decision: ERPNext on Frappe Cloud (Target Architecture)
 
-This PRD reflects the strategic decision to build on **ERPNext Field Service
-Management** (hosted on Frappe Cloud) rather than OpenProject, providing:
+This PRD describes the **target architecture** using **ERPNext Field Service
+Management** (hosted on Frappe Cloud). **Migration status: Phase 1 complete**
+(config layer, stub client), **Phase 2 pending** (live API integration).
+OpenProject remains the default and functional backend.
+
+Target ERPNext benefits:
 
 - Industry-standard FSM workflows (service calls, maintenance, installations)
 - Custom DocTypes for mining-specific metadata
@@ -53,7 +57,7 @@ Management** (hosted on Frappe Cloud) rather than OpenProject, providing:
 - Git-based deployment for custom apps (flrts_extensions)
 
 See [ADR-006](../architecture/adr/ADR-006-erpnext-frappe-cloud-migration.md) for
-migration rationale.
+migration roadmap and 10N-243 for Phase 1 completion details.
 
 ## Reading Order for Stakeholders
 

--- a/docs/prd/prd.md
+++ b/docs/prd/prd.md
@@ -539,9 +539,9 @@ we have reliable API integration.
 
 **Acceptance Criteria:**
 
-1. CREATE work package workflow via POST /api/v3/work_packages
-2. READ work packages workflow with filtering
-3. UPDATE work package workflow via PATCH
+1. CREATE Maintenance Visit workflow via POST /api/resource/Maintenance Visit
+2. READ Maintenance Visit workflow with appropriate filters
+3. UPDATE workflow via PATCH /api/resource/Maintenance Visit/\<name\>
 4. ARCHIVE workflow via status change (never DELETE)
 5. Error handling with retries
 6. Response transformation to standard format

--- a/docs/setup/frappe-cloud-site.md
+++ b/docs/setup/frappe-cloud-site.md
@@ -1,5 +1,13 @@
 # Frappe Cloud Site Setup Guide
 
+> **⚠️ MIGRATION STATUS**: This setup guide describes the **target
+> infrastructure** for ERPNext on Frappe Cloud. **Application migration: Phase 1
+> complete** (config layer, stub client), **Phase 2 pending** (live API
+> integration). Infrastructure is provisioned but **OpenProject remains the
+> default backend**. See
+> [ADR-006](../architecture/adr/ADR-006-erpnext-frappe-cloud-migration.md) for
+> migration roadmap.
+
 **Status**: Active **Supersedes**: OpenProject deployment documentation (see
 `docs/archive/openproject/`) **Related**:
 [ADR-006 ERPNext Frappe Cloud Migration](../architecture/adr/ADR-006-erpnext-frappe-cloud-migration.md)

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,11 +1,11 @@
 # FLRTS Infrastructure
 
-> ⚠️ **MIGRATION NOTICE**: OpenProject infrastructure has been replaced by
-> ERPNext on Frappe Cloud. See
+> ⚠️ **MIGRATION IN PROGRESS**: This infrastructure describes the target ERPNext
+> on Frappe Cloud architecture. Application migration is phased: **Phase 1
+> complete** (config layer, ERPNext stub client), **Phase 2 pending** (live API
+> calls). OpenProject remains the default and only functional backend. See
 > [ADR-006](../docs/architecture/adr/ADR-006-erpnext-frappe-cloud-migration.md)
-> for rationale. Note: Application client migration is phased. The OpenProject
-> backend remains the default in Phase 1 while the ERPNext client is stubbed
-> (see 10N-243).
+> for migration roadmap and 10N-243 for Phase 1 details.
 
 ## Overview
 

--- a/packages/sync-service/src/clients/erpnext.ts
+++ b/packages/sync-service/src/clients/erpnext.ts
@@ -55,13 +55,13 @@ export class ERPNextClient {
     this.apiUrl = config.apiUrl || '';
 
     if (!this.configured) {
-      if (process.env.NODE_ENV !== 'test') {
+      if (process.env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'production') {
         console.warn(
           '[ERPNextClient] Created stub client. Credentials missing. ' +
             'Set ERPNEXT_API_URL, ERPNEXT_API_KEY, ERPNEXT_API_SECRET to enable live API calls.'
         );
       }
-    } else if (process.env.NODE_ENV !== 'test') {
+    } else if (process.env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'production') {
       console.log('[ERPNextClient] Initialized (stub mode, Phase 1):', this.apiUrl);
     }
   }

--- a/packages/sync-service/src/config.ts
+++ b/packages/sync-service/src/config.ts
@@ -66,7 +66,7 @@ export function getBackendConfig(): BackendConfig {
     }
 
     // Fall back to OpenProject if ERPNext vars incomplete
-    if (process.env.NODE_ENV !== 'test') {
+    if (process.env.NODE_ENV !== 'test' && process.env.NODE_ENV !== 'production') {
       console.warn(
         '[Config] USE_ERPNEXT=true but ERPNEXT_API_URL, ERPNEXT_API_KEY, or ERPNEXT_API_SECRET missing. ' +
           'Falling back to OpenProject backend. ' +


### PR DESCRIPTION
## Summary

Completes three quick-win issues from Phase 2 coordination:
- **10N-249**: Clarify ERPNext migration status (Phase 1 vs complete)  
- **10N-247**: Suppress non-essential init logs in production
- **10N-248**: Fix CodeRabbit findings from PR #42

## Changes

### 10N-249: Migration Status Clarification ✅
Added Phase 1/2 status banners to all infrastructure and architecture docs:
- `infrastructure/README.md`
- `docs/architecture/README.md`
- `docs/prd/README.md`
- `docs/deployment/FRAPPE_CLOUD_DEPLOYMENT.md`
- `docs/architecture/frappe-cloud-environment.md`
- `docs/setup/frappe-cloud-site.md`

All docs now clearly state:
- **Phase 1 complete**: config layer, ERPNext stub client
- **Phase 2 pending**: live API integration
- **Current default**: OpenProject (functional)

### 10N-247: Logging Policy ✅
Suppressed init logs in production environments:
- `packages/sync-service/src/clients/erpnext.ts`: Added `NODE_ENV !== 'production'` guard (line 20)
- `packages/sync-service/src/config.ts`: Added `NODE_ENV !== 'production'` guard (line 62)
- Logs now only appear in development (neither test nor production)
- Addresses Qodo security compliance (no config disclosure in prod logs)

**Note**: Logging policy doc (docs/architecture/logging-policy.md) deferred to follow-up issue per CodeRabbit feedback.

### 10N-248: CodeRabbit Doc Findings ✅
- Updated PRD Story 3.1 with correct ERPNext Maintenance Visit endpoints
- Removed orphaned comment in `.security-ignore`  
- Auto-fixed markdownlint violations (MD022/31/32) in:
  - `docs/MVP-FEATURES.md`
  - `docs/erpnext/research/erpnext-fsm-module-analysis.md`
  - `docs/FUTURE_FEATURES.md`

## Test Plan
- [x] All P0 unit tests pass (61 passed, 1 skipped)
- [x] Security review clean (no vulnerabilities)
- [x] Pre-commit hooks (prettier, markdownlint, eslint) passed
- [x] All acceptance criteria met for 10N-247, 10N-248, 10N-249

## Related Issues
- Closes #46 (10N-247)
- Closes #47 (10N-248)
- Closes #48 (10N-249)
- Replaces #49 (clean history)
- Part of #44 (10N-243 Phase 2 coordination)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)